### PR TITLE
戻るボタン実装

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -105,6 +105,7 @@ export const drawLine = () => {
     endPointX = event.clientX;
     endPointY = event.clientY;
     // store lines position
+    if (startPointX === endPointX && startPointY === endPointY) return;
     storedLines.push({
       startPointX: startPointX,
       startPointY: startPointY,
@@ -163,6 +164,26 @@ export const drawLine = () => {
     if (storedLines.length === 0) {
       return;
     }
+    for (let i = 0; i < storedLines.length; i++) {
+      drawLine(
+        storedLines[i].startPointX,
+        storedLines[i].startPointY,
+        storedLines[i].endPointX,
+        storedLines[i].endPointY,
+        storedLines[i].lineType,
+        storedLines[i].color
+      );
+    }
+  };
+
+  // back
+  const backButton = document.querySelector(".draw-line-back-button");
+  backButton.addEventListener("click", () => {
+    backDrawLine();
+  });
+  const backDrawLine = () => {
+    context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+    storedLines = storedLines.slice(0, -1);
     for (let i = 0; i < storedLines.length; i++) {
       drawLine(
         storedLines[i].startPointX,

--- a/src/draw.js
+++ b/src/draw.js
@@ -176,7 +176,7 @@ export const drawLine = () => {
     }
   };
 
-  // back
+  // back to previous states
   const backButton = document.querySelector(".draw-line-back-button");
   backButton.addEventListener("click", () => {
     storedLines.pop();

--- a/src/draw.js
+++ b/src/draw.js
@@ -179,22 +179,9 @@ export const drawLine = () => {
   // back
   const backButton = document.querySelector(".draw-line-back-button");
   backButton.addEventListener("click", () => {
-    backDrawLine();
+    storedLines.pop();
+    resetAndDraw();
   });
-  const backDrawLine = () => {
-    context.clearRect(0, 0, context.canvas.width, context.canvas.height);
-    storedLines = storedLines.slice(0, -1);
-    for (let i = 0; i < storedLines.length; i++) {
-      drawLine(
-        storedLines[i].startPointX,
-        storedLines[i].startPointY,
-        storedLines[i].endPointX,
-        storedLines[i].endPointY,
-        storedLines[i].lineType,
-        storedLines[i].color
-      );
-    }
-  };
 
   // reset all lines
   const resetButton = document.querySelector(".draw-line-reset-button");

--- a/src/item.js
+++ b/src/item.js
@@ -64,6 +64,12 @@ export const createItem = () => {
   wrapper.appendChild(footer);
 
   // create reset button element
+  const backButton = document.createElement("button");
+  backButton.innerHTML = "戻す";
+  backButton.className = "draw-line-back-button";
+  footer.appendChild(backButton);
+
+  // create reset button element
   const resetButton = document.createElement("button");
   resetButton.innerHTML = "リセット";
   resetButton.className = "draw-line-reset-button";


### PR DESCRIPTION
## 概要

`描画を一つ前に戻す`ボタンを実装
※戻るボタンのcssは当てていない

## 実装内容

### 戻るボタン実装

- items.jsに`戻る`ボタンを追加
- draw.jsに`戻る`ボタンを押した際のイベントハンドラを追加

### 仕様修正

プロパティウィンドウで色や線のタイプを選択する際のボタン押下時でも、
点を描画している判定になっていたので、
mouseDownの位置とmouseUpの位置が同じ際は描画しないように修正。